### PR TITLE
Fixed "/Users/runner/work/SharpSDL3/SharpSDL3/tests/SharpSDL3.Tests/N…

### DIFF
--- a/tests/SharpSDL3.Tests/NativeSurfaceTests.cs
+++ b/tests/SharpSDL3.Tests/NativeSurfaceTests.cs
@@ -24,7 +24,7 @@ public class NativeSurfaceTests
     public void Surface_CreateAndDestroy_MultipleFormats()
     {
         if (!RequireSdl()) return;
-        var formats = new[] { PixelFormat.Rgba8888, PixelFormat.Argb8888, PixelFormat.Rgb888 };
+        var formats = new[] { PixelFormat.Rgba8888, PixelFormat.Argb8888, PixelFormat.Bgra8888 };
         foreach (var fmt in formats)
         {
             nint surface = Sdl.CreateSurface(64, 64, fmt);

--- a/tests/SharpSDL3.Tests/NativeSurfaceTests.cs
+++ b/tests/SharpSDL3.Tests/NativeSurfaceTests.cs
@@ -24,7 +24,7 @@ public class NativeSurfaceTests
     public void Surface_CreateAndDestroy_MultipleFormats()
     {
         if (!RequireSdl()) return;
-        var formats = new[] { PixelFormat.Rgba8888, PixelFormat.Argb8888, PixelFormat.Bgra8888 };
+        var formats = new[] { PixelFormat.Rgba8888, PixelFormat.Argb8888, PixelFormat.Xrgb8888 };
         foreach (var fmt in formats)
         {
             nint surface = Sdl.CreateSurface(64, 64, fmt);


### PR DESCRIPTION
…ativeSurfaceTests.cs(27,87): error CS0117: 'PixelFormat' does not contain a definition for 'Rgb888' [/Users/runner/work/SharpSDL3/SharpSDL3/tests/SharpSDL3.Tests/SharpSDL3.Tests.csproj]"; changed to Bgra8888 for testing

## Summary by Sourcery

Update surface format test to use a valid pixel format constant.

Bug Fixes:
- Replace unsupported PixelFormat.Rgb888 usage in NativeSurfaceTests with a supported format to resolve compilation failure.

Tests:
- Adjust NativeSurfaceTests surface creation formats to cover Bgra8888 instead of the invalid Rgb888.